### PR TITLE
Fix submitQuiz brace and sanitize user input

### DIFF
--- a/index.html
+++ b/index.html
@@ -1588,7 +1588,7 @@
                 currentQuiz = selectedQuiz;
             }
             
-            window.quizTakerName = name;
+            window.quizTakerName = sanitizeHTML(name);
             showSection('loading-section');
             setTimeout(() => loadQuizQuestions(), 500);
         }
@@ -1747,7 +1747,8 @@
                 setTimeout(() => {
                     submitButton.textContent = originalText;
                     submitButton.disabled = false;
-                    }, 1000);
+                }, 1000);
+            }
         }
 
         function backToHome() {
@@ -1757,6 +1758,12 @@
         }
 
         // Utility functions
+        function sanitizeHTML(str) {
+            const div = document.createElement('div');
+            div.textContent = str;
+            return div.innerHTML;
+        }
+
         function showSection(sectionId) {
             console.log('showSection called with:', sectionId);
             


### PR DESCRIPTION
## Summary
- Close the `submitQuiz` function properly to restore expected behavior
- Escape user-provided names to avoid XSS in results rendering

## Testing
- `node --check script.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `pip install html5validator` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b37455a08326b70c4e16a12cd8ae