### PR TITLE
Check unanswered questions before scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,28 @@
                 submitButton.textContent = '⏳ Processing...';
                 submitButton.disabled = true;
             }
-            
+
+            // Verify all questions have been answered before scoring
+            const hasUnanswered = currentQuestions.some((question, index) => {
+                if (question.type === 'multiple' || question.type === 'true_false') {
+                    return !document.querySelector(`input[name="q${index}"]:checked`);
+                }
+                if (question.type === 'short') {
+                    const textArea = document.getElementById(`q${index}_text`);
+                    return !textArea || textArea.value.trim() === '';
+                }
+                return false;
+            });
+
+            if (hasUnanswered) {
+                alert('Please answer all questions before submitting.');
+                if (submitButton) {
+                    submitButton.textContent = originalText;
+                    submitButton.disabled = false;
+                }
+                return;
+            }
+
             let score = 0;
             wrongAnswers = [];
             const allAnswers = [];


### PR DESCRIPTION
## Summary
- Prevent quiz submission when unanswered questions remain
- Alert users and restore submit button state instead of computing score

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b66e2ee88326aa7887fcbb8d463d