### PR TITLE
Use application/json for quiz submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # ALS Quiz
+
+## Posting Quiz Results
+
+The Google Apps Script backing this project parses incoming data as JSON. All
+`POST` requests, such as quiz submissions, must send a JSON payload and include
+the `Content-Type: application/json` header.

--- a/index.html
+++ b/index.html
@@ -1825,8 +1825,8 @@
             try {
                 const response = await fetch(CONFIG.webAppUrl, {
                     method: 'POST',
-                    headers: { 
-                        'Content-Type': 'text/plain;charset=utf-8'  // Changed from application/json
+                    headers: {
+                        'Content-Type': 'application/json'
                     },
                     body: JSON.stringify(quizResults)
                 });


### PR DESCRIPTION
## Summary
- send quiz results with `Content-Type: application/json`
- document that Google Apps Script expects JSON payloads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b67087788326b9620938750204ec