### PR TITLE
chore: proxy Google Script URLs through backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+WEB_APP_URL=https://script.google.com/macros/s/YOUR_SCRIPT_ID/exec
+QUIZ_LIST_URL=https://script.google.com/macros/s/YOUR_SCRIPT_ID/exec
+QUESTIONS_URL=https://script.google.com/macros/s/YOUR_SCRIPT_ID/exec
+SHEET_URL=https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/edit
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # ALS Quiz
+
+## Configuration
+
+Sensitive Google Script URLs are now kept on the server instead of the browser.
+
+1. Copy `.env.example` to `.env` and fill in your real URLs.
+   - `WEB_APP_URL` – Apps Script endpoint for saving results.
+   - `QUIZ_LIST_URL` – Apps Script endpoint used to fetch available quizzes.
+   - `QUESTIONS_URL` – Apps Script endpoint used for quiz questions.
+   - `SHEET_URL` – direct link to the Google Sheet.
+2. Start the local server:
+
+```bash
+node server.js
+```
+
+The front end now talks only to relative paths:
+
+- `/api/webapp` – save results and connectivity test.
+- `/api/quizzes` – list available quizzes.
+- `/api/questions` – fetch or add quiz questions.
+- `/sheet` – redirect to the configured sheet.
+
+Ensure these environment variables are set wherever the app is deployed.

--- a/index.html
+++ b/index.html
@@ -1453,10 +1453,10 @@
     <script>
         // CONFIGURATION
         const CONFIG = {
-            sheetUrl: 'https://docs.google.com/spreadsheets/d/1hl8L_oPTP5A47pIoGjaOV9vWg85x1BBSTEsUOXjqucE/edit?usp=sharing',
-            webAppUrl: 'https://script.google.com/macros/s/AKfycbw917rSpnmVmrA07IDLWt699GJ3lZlGo8wYwpDCc77BhuaT4S_HMIuOYgLbTCtDhwNp/exec',
-            quizListUrl: 'https://script.google.com/macros/s/AKfycbw917rSpnmVmrA07IDLWt699GJ3lZlGo8wYwpDCc77BhuaT4S_HMIuOYgLbTCtDhwNp/exec?action=getQuizzes',
-            questionsUrl: 'https://script.google.com/macros/s/AKfycbw917rSpnmVmrA07IDLWt699GJ3lZlGo8wYwpDCc77BhuaT4S_HMIuOYgLbTCtDhwNp/exec?action=getQuestions'
+            sheetUrl: '/sheet',
+            webAppUrl: '/api/webapp',
+            quizListUrl: '/api/quizzes',
+            questionsUrl: '/api/questions'
         };
 
                 
@@ -1539,7 +1539,7 @@
             statusElement.className = 'status-indicator status-warning';
             
             try {
-                const response = await fetch(CONFIG.webAppUrl + '?test=true');
+                const response = await fetch(`${CONFIG.webAppUrl}?test=true`);
                 if (response.ok) {
                     statusElement.textContent = '✅ Connected';
                     statusElement.className = 'status-indicator status-connected';
@@ -1630,7 +1630,7 @@
             const feedback = document.getElementById('aq-feedback');
             feedback.textContent = 'Submitting...';
             try {
-                const response = await fetch(CONFIG.questionsUrl + '?action=addQuestion', {
+                const response = await fetch(CONFIG.questionsUrl, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload)
@@ -1918,7 +1918,7 @@
 
         async function loadQuizQuestions() {
             try {
-                const url = `${CONFIG.questionsUrl}&quiz=${encodeURIComponent(currentQuiz)}`;
+                const url = `${CONFIG.questionsUrl}?quiz=${encodeURIComponent(currentQuiz)}`;
                 const response = await fetch(url);
                 const data = await response.json();
                 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "als-quiz",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No test specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,77 @@
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const WEB_APP_URL = process.env.WEB_APP_URL || '';
+const QUESTIONS_URL = process.env.QUESTIONS_URL || '';
+const QUIZ_LIST_URL = process.env.QUIZ_LIST_URL || '';
+const SHEET_URL = process.env.SHEET_URL || '';
+
+function proxyRequest(target, req, res) {
+  try {
+    const url = new URL(target);
+    const options = {
+      method: req.method,
+      headers: { ...req.headers, host: url.host }
+    };
+    const lib = url.protocol === 'https:' ? https : http;
+    const proxyReq = lib.request(url, options, proxyRes => {
+      res.writeHead(proxyRes.statusCode, proxyRes.headers);
+      proxyRes.pipe(res, { end: true });
+    });
+    proxyReq.on('error', () => {
+      res.writeHead(500);
+      res.end('Proxy error');
+    });
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      req.pipe(proxyReq, { end: true });
+    } else {
+      proxyReq.end();
+    }
+  } catch (err) {
+    res.writeHead(500);
+    res.end('Proxy error');
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/api/webapp')) {
+    const query = new URL(req.url, 'http://localhost').search;
+    proxyRequest(WEB_APP_URL + query, req, res);
+  } else if (req.url.startsWith('/api/quizzes')) {
+    proxyRequest(`${QUIZ_LIST_URL}?action=getQuizzes`, req, res);
+  } else if (req.url.startsWith('/api/questions')) {
+    if (req.method === 'GET') {
+      const params = new URL(req.url, 'http://localhost').searchParams;
+      const quiz = params.get('quiz') || '';
+      const target = `${QUESTIONS_URL}?action=getQuestions&quiz=${encodeURIComponent(quiz)}`;
+      proxyRequest(target, req, res);
+    } else if (req.method === 'POST') {
+      const target = `${QUESTIONS_URL}?action=addQuestion`;
+      proxyRequest(target, req, res);
+    } else {
+      res.writeHead(405);
+      res.end('Method Not Allowed');
+    }
+  } else if (req.url.startsWith('/sheet')) {
+    res.writeHead(302, { Location: SHEET_URL });
+    res.end();
+  } else {
+    const filePath = path.join(__dirname, req.url === '/' ? '/index.html' : req.url);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Not Found');
+      } else {
+        res.writeHead(200);
+        res.end(data);
+      }
+    });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Hide Google Script endpoints behind a simple Node proxy
- Update front-end to use relative API paths
- Document environment variable configuration for the proxy server

## Testing
- `npm test`
- `WEB_APP_URL=http://example.com QUIZ_LIST_URL=http://example.com QUESTIONS_URL=http://example.com SHEET_URL=http://example.com node server.js` *(started and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b6736d588326beca506342eb9623