### PR TITLE
Display bulk import validation feedback

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -5,6 +5,9 @@ function doPost(e) {
   if (action === 'addQuestion') {
     return handleAddQuestion(e);
   }
+  if (action === 'bulkImport') {
+    return handleBulkImport(e);
+  }
   return ContentService.createTextOutput(JSON.stringify({
     success: false,
     errors: ['Unsupported action']
@@ -53,4 +56,61 @@ function handleAddQuestion(e) {
   sheet.appendRow([data.quiz, data.type, data.question, options, data.correct, data.explanation]);
 
   return ContentService.createTextOutput(JSON.stringify({ success: true })).setMimeType(ContentService.MimeType.JSON);
+}
+
+function handleBulkImport(e) {
+  let questions = [];
+  try {
+    questions = JSON.parse(e.postData.contents);
+    if (!Array.isArray(questions)) {
+      throw new Error('Invalid format');
+    }
+  } catch (err) {
+    return ContentService.createTextOutput(JSON.stringify({
+      success: false,
+      errors: ['Invalid JSON']
+    })).setMimeType(ContentService.MimeType.JSON);
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(SHEET_NAME);
+  if (!sheet) {
+    return ContentService.createTextOutput(JSON.stringify({
+      success: false,
+      errors: ['Sheet not found']
+    })).setMimeType(ContentService.MimeType.JSON);
+  }
+
+  const required = ['quiz', 'type', 'question', 'correct', 'explanation'];
+  let successCount = 0;
+  const errorDetails = [];
+
+  questions.forEach((data, index) => {
+    const errors = [];
+    required.forEach(field => {
+      if (!data[field]) {
+        errors.push(`${field} is required`);
+      }
+    });
+    if (data.type === 'multiple' && (!data.options || !data.options.length)) {
+      errors.push('options are required for multiple choice');
+    }
+
+    if (errors.length) {
+      errorDetails.push({ index: index + 1, errors: errors });
+    } else {
+      const options = data.options ? JSON.stringify(data.options) : '';
+      sheet.appendRow([data.quiz, data.type, data.question, options, data.correct, data.explanation]);
+      successCount++;
+    }
+  });
+
+  return ContentService.createTextOutput(JSON.stringify({
+    success: errorDetails.length === 0,
+    summary: {
+      successful: successCount,
+      failed: errorDetails.length
+    },
+    errors: errorDetails
+  })).setMimeType(ContentService.MimeType.JSON);
 }

--- a/index.html
+++ b/index.html
@@ -1655,8 +1655,12 @@
             const modal = document.getElementById('bulk-import-modal');
             if (modal) {
                 document.getElementById('bulk-import-form').reset();
-                document.getElementById('bulk-summary').textContent = '';
-                document.getElementById('bulk-errors').innerHTML = '';
+                const summary = document.getElementById('bulk-summary');
+                const errors = document.getElementById('bulk-errors');
+                summary.textContent = '';
+                errors.innerHTML = '';
+                summary.classList.add('hidden');
+                errors.classList.add('hidden');
                 modal.classList.remove('hidden');
             }
         }
@@ -1672,7 +1676,9 @@
             const summaryEl = document.getElementById('bulk-summary');
             const errorsEl = document.getElementById('bulk-errors');
             summaryEl.textContent = 'Submitting...';
+            summaryEl.classList.remove('hidden');
             errorsEl.innerHTML = '';
+            errorsEl.classList.add('hidden');
 
             let payload;
             try {
@@ -1693,7 +1699,7 @@
                 if (result.summary) {
                     summaryEl.textContent = `✅ ${result.summary.successful} added, ❌ ${result.summary.failed} failed`;
                 } else {
-                    summaryEl.textContent = '';
+                    summaryEl.classList.add('hidden');
                 }
                 if (result.errors && result.errors.length) {
                     const list = document.createElement('ul');
@@ -1703,7 +1709,10 @@
                         list.appendChild(li);
                     });
                     errorsEl.appendChild(list);
+                    errorsEl.classList.remove('hidden');
                     console.error('Bulk import validation errors', result.errors);
+                } else {
+                    errorsEl.classList.add('hidden');
                 }
                 if (result.summary && result.summary.failed === 0) {
                     refreshQuestions();
@@ -2298,8 +2307,8 @@ Focus on actionable knowledge I can apply immediately in my maintenance work.`;
                         <button type="submit" class="btn btn-success">Submit</button>
                         <button type="button" class="btn btn-danger" onclick="closeBulkImport()">Cancel</button>
                     </div>
-                    <div id="bulk-summary" style="margin-top:10px;"></div>
-                    <div id="bulk-errors" style="margin-top:10px;color:red;"></div>
+                    <div id="bulk-summary" class="hidden" style="margin-top:10px;"></div>
+                    <div id="bulk-errors" class="hidden" style="margin-top:10px;color:red;"></div>
                 </form>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -1653,16 +1653,16 @@
 
         function openBulkImport() {
             const modal = document.getElementById('bulk-import-modal');
-            if (modal) {
-                document.getElementById('bulk-import-form').reset();
-                const summary = document.getElementById('bulk-summary');
-                const errors = document.getElementById('bulk-errors');
-                summary.textContent = '';
-                errors.innerHTML = '';
-                summary.classList.add('hidden');
-                errors.classList.add('hidden');
-                modal.classList.remove('hidden');
-            }
+            const form = document.getElementById('bulk-import-form');
+            const summary = document.getElementById('bulk-summary');
+            const errors = document.getElementById('bulk-errors');
+            if (!modal || !form || !summary || !errors) return;
+            form.reset();
+            summary.textContent = '';
+            errors.innerHTML = '';
+            summary.classList.add('hidden');
+            errors.classList.add('hidden');
+            modal.classList.remove('hidden');
         }
 
         function closeBulkImport() {
@@ -1675,10 +1675,13 @@
             const textarea = document.getElementById('bulk-questions');
             const summaryEl = document.getElementById('bulk-summary');
             const errorsEl = document.getElementById('bulk-errors');
+            const submitBtn = event.submitter || event.target.querySelector('button[type="submit"]');
+            if (!textarea || !summaryEl || !errorsEl || !submitBtn) return;
             summaryEl.textContent = 'Submitting...';
             summaryEl.classList.remove('hidden');
             errorsEl.innerHTML = '';
             errorsEl.classList.add('hidden');
+            submitBtn.disabled = true;
 
             let payload;
             try {
@@ -1686,6 +1689,7 @@
             } catch (err) {
                 summaryEl.textContent = '❌ Invalid JSON';
                 console.error('Bulk import JSON parse error', err);
+                submitBtn.disabled = false;
                 return;
             }
 
@@ -1721,6 +1725,8 @@
             } catch (err) {
                 summaryEl.textContent = '❌ Error';
                 console.error('Bulk import request failed', err);
+            } finally {
+                submitBtn.disabled = false;
             }
         }
 

--- a/index.html
+++ b/index.html
@@ -1651,6 +1651,70 @@
             }
         }
 
+        function openBulkImport() {
+            const modal = document.getElementById('bulk-import-modal');
+            if (modal) {
+                document.getElementById('bulk-import-form').reset();
+                document.getElementById('bulk-summary').textContent = '';
+                document.getElementById('bulk-errors').innerHTML = '';
+                modal.classList.remove('hidden');
+            }
+        }
+
+        function closeBulkImport() {
+            const modal = document.getElementById('bulk-import-modal');
+            if (modal) modal.classList.add('hidden');
+        }
+
+        async function submitBulkImport(event) {
+            event.preventDefault();
+            const textarea = document.getElementById('bulk-questions');
+            const summaryEl = document.getElementById('bulk-summary');
+            const errorsEl = document.getElementById('bulk-errors');
+            summaryEl.textContent = 'Submitting...';
+            errorsEl.innerHTML = '';
+
+            let payload;
+            try {
+                payload = JSON.parse(textarea.value);
+            } catch (err) {
+                summaryEl.textContent = '❌ Invalid JSON';
+                console.error('Bulk import JSON parse error', err);
+                return;
+            }
+
+            try {
+                const response = await fetch(CONFIG.questionsUrl + '?action=bulkImport', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const result = await response.json();
+                if (result.summary) {
+                    summaryEl.textContent = `✅ ${result.summary.successful} added, ❌ ${result.summary.failed} failed`;
+                } else {
+                    summaryEl.textContent = '';
+                }
+                if (result.errors && result.errors.length) {
+                    const list = document.createElement('ul');
+                    result.errors.forEach(item => {
+                        const li = document.createElement('li');
+                        li.textContent = `Question ${item.index}: ${item.errors.join(', ')}`;
+                        list.appendChild(li);
+                    });
+                    errorsEl.appendChild(list);
+                    console.error('Bulk import validation errors', result.errors);
+                }
+                if (result.summary && result.summary.failed === 0) {
+                    refreshQuestions();
+                    setTimeout(() => { closeBulkImport(); }, 1000);
+                }
+            } catch (err) {
+                summaryEl.textContent = '❌ Error';
+                console.error('Bulk import request failed', err);
+            }
+        }
+
         // Initialize app
         async function initializeApp() {
             await testConnection();
@@ -2182,6 +2246,7 @@ Focus on actionable knowledge I can apply immediately in my maintenance work.`;
                     <button class="btn btn-secondary" onclick="testImages()">🖼️ Images</button>
                     <button class="btn btn-secondary" onclick="refreshQuestions()">🔄 Refresh</button>
                     <button class="btn btn-secondary" onclick="openAddQuestionForm()">➕ Add Question</button>
+                    <button class="btn btn-secondary" onclick="openBulkImport()">📥 Bulk Import</button>
                 </div>
             </div>
         </div>
@@ -2218,6 +2283,23 @@ Focus on actionable knowledge I can apply immediately in my maintenance work.`;
                         <button type="button" class="btn btn-danger" onclick="closeAddQuestion()">Cancel</button>
                     </div>
                     <div id="aq-feedback" style="margin-top:10px;"></div>
+                </form>
+            </div>
+        </div>
+
+        <div id="bulk-import-modal" class="modal hidden">
+            <div class="modal-content">
+                <h3>Bulk Import Questions</h3>
+                <form id="bulk-import-form" onsubmit="submitBulkImport(event)">
+                    <label>Questions JSON
+                        <textarea id="bulk-questions" required></textarea>
+                    </label>
+                    <div class="modal-actions">
+                        <button type="submit" class="btn btn-success">Submit</button>
+                        <button type="button" class="btn btn-danger" onclick="closeBulkImport()">Cancel</button>
+                    </div>
+                    <div id="bulk-summary" style="margin-top:10px;"></div>
+                    <div id="bulk-errors" style="margin-top:10px;color:red;"></div>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add bulk question import modal with per-question error list and success/failure summary
- route bulkImport action on server and process each question
- log validation issues to the browser console for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b7f10a248326ae6b23f8f7ec5d80