### PR TITLE
Add bulk question insertion handler

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -5,6 +5,9 @@ function doPost(e) {
   if (action === 'addQuestion') {
     return handleAddQuestion(e);
   }
+  if (action === 'addQuestions') {
+    return handleAddQuestions(e);
+  }
   return ContentService.createTextOutput(JSON.stringify({
     success: false,
     errors: ['Unsupported action']
@@ -53,4 +56,70 @@ function handleAddQuestion(e) {
   sheet.appendRow([data.quiz, data.type, data.question, options, data.correct, data.explanation]);
 
   return ContentService.createTextOutput(JSON.stringify({ success: true })).setMimeType(ContentService.MimeType.JSON);
+}
+
+function handleAddQuestions(e) {
+  let data = [];
+  try {
+    data = JSON.parse(e.postData.contents);
+  } catch (err) {
+    return ContentService.createTextOutput(JSON.stringify({
+      success: false,
+      errors: ['Invalid JSON'],
+    })).setMimeType(ContentService.MimeType.JSON);
+  }
+
+  if (!Array.isArray(data)) {
+    return ContentService.createTextOutput(JSON.stringify({
+      success: false,
+      errors: ['Expected an array of questions'],
+    })).setMimeType(ContentService.MimeType.JSON);
+  }
+
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(SHEET_NAME);
+  if (!sheet) {
+    return ContentService.createTextOutput(JSON.stringify({
+      success: false,
+      errors: ['Sheet not found'],
+    })).setMimeType(ContentService.MimeType.JSON);
+  }
+
+  const required = ['quiz', 'type', 'question', 'correct', 'explanation'];
+  const rows = [];
+  const errors = [];
+
+  data.forEach((item, index) => {
+    const rowErrors = [];
+    required.forEach(field => {
+      if (!item[field]) {
+        rowErrors.push(`${field} is required`);
+      }
+    });
+    if (item.type === 'multiple' && (!item.options || !item.options.length)) {
+      rowErrors.push('options are required for multiple choice');
+    }
+
+    if (rowErrors.length) {
+      errors.push({ index: index, errors: rowErrors });
+      return;
+    }
+
+    const options = item.options ? JSON.stringify(item.options) : '';
+    rows.push([item.quiz, item.type, item.question, options, item.correct, item.explanation]);
+  });
+
+  if (rows.length) {
+    if (typeof sheet.appendRows === 'function') {
+      sheet.appendRows(rows);
+    } else {
+      rows.forEach(row => sheet.appendRow(row));
+    }
+  }
+
+  return ContentService.createTextOutput(JSON.stringify({
+    success: true,
+    inserted: rows.length,
+    errors: errors,
+  })).setMimeType(ContentService.MimeType.JSON);
 }


### PR DESCRIPTION
## Summary
- support `addQuestions` action in `doPost`
- implement `handleAddQuestions` to validate and insert multiple questions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b7f074008326888797887ad2e972