### PR TITLE
feat: add bulk question submission handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -1651,6 +1651,40 @@
             }
         }
 
+        async function submitBulkQuestions(event) {
+            event.preventDefault();
+            const textarea = event.target.querySelector('textarea');
+            const submitBtn = event.submitter || event.target.querySelector('button[type="submit"]');
+            const feedback = document.getElementById('bq-feedback');
+
+            if (!textarea || !submitBtn || !feedback) return;
+
+            const questions = parseGPTQuiz(textarea.value);
+            feedback.textContent = 'Submitting...';
+            submitBtn.disabled = true;
+
+            try {
+                const response = await fetch(CONFIG.questionsUrl + '?action=addQuestions', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(questions)
+                });
+                const result = await response.json();
+                if (result.success) {
+                    feedback.textContent = '✅ Added!';
+                    textarea.value = '';
+                    refreshQuestions();
+                    setTimeout(() => { feedback.textContent = ''; }, 1000);
+                } else {
+                    feedback.textContent = '❌ ' + (result.errors ? result.errors.join(', ') : 'Failed');
+                }
+            } catch (err) {
+                feedback.textContent = '❌ Error';
+            } finally {
+                submitBtn.disabled = false;
+            }
+        }
+
         // Initialize app
         async function initializeApp() {
             await testConnection();


### PR DESCRIPTION
## Summary
- add `submitBulkQuestions` to parse textarea input and POST parsed questions to backend
- disable submit button and show loading message during request

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b7eff1d48326bba9de973a77ce23