### PR TITLE
feat: add GPT quiz parser for bulk question uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1617,17 +1617,105 @@
             list.appendChild(input);
         }
 
+        function parseGPTQuiz(rawText) {
+            if (!rawText || !rawText.trim()) {
+                throw new Error('No quiz text provided');
+            }
+
+            const blocks = rawText.trim().split(/\n\s*\n/);
+            const questions = [];
+            const errors = [];
+
+            blocks.forEach((block, idx) => {
+                const lines = block.trim().split(/\n/).map(l => l.trim()).filter(Boolean);
+                if (lines.length === 0) return;
+
+                let question = lines.shift().replace(/^\d+[\.\)\-\s]*/, '').trim();
+                const options = [];
+                let correct = '';
+                let explanation = '';
+
+                lines.forEach(line => {
+                    const optMatch = line.match(/^[A-Z][\)\.\-\s]+(.+)/i);
+                    if (optMatch) {
+                        options.push(optMatch[1].trim());
+                        return;
+                    }
+                    const ansMatch = line.match(/^Answer:\s*(.+)/i);
+                    if (ansMatch) {
+                        correct = ansMatch[1].trim();
+                        return;
+                    }
+                    const expMatch = line.match(/^Explanation:\s*(.+)/i);
+                    if (expMatch) {
+                        explanation = expMatch[1].trim();
+                        return;
+                    }
+                });
+
+                if (!question) errors.push(`Block ${idx + 1}: Missing question`);
+                if (!correct) errors.push(`Block ${idx + 1}: Missing answer`);
+                if (!explanation) errors.push(`Block ${idx + 1}: Missing explanation`);
+
+                if (question && correct && explanation) {
+                    questions.push({ question, options, correct, explanation });
+                }
+            });
+
+            if (errors.length) {
+                throw new Error(errors.join(' | '));
+            }
+
+            return questions;
+        }
+
         async function submitAddQuestion(event) {
             event.preventDefault();
+            const feedback = document.getElementById('aq-feedback');
+            const bulkText = document.getElementById('aq-bulk') ? document.getElementById('aq-bulk').value.trim() : '';
+            const quiz = document.getElementById('aq-quiz').value;
+            const type = document.getElementById('aq-type').value;
+
+            if (bulkText) {
+                feedback.textContent = 'Submitting...';
+                try {
+                    const questions = parseGPTQuiz(bulkText);
+                    for (const q of questions) {
+                        const payload = { quiz, type, ...q };
+                        const response = await fetch(CONFIG.questionsUrl + '?action=addQuestion', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(payload)
+                        });
+                        const result = await response.json();
+                        if (!result.success) {
+                            throw new Error(result.errors ? result.errors.join(', ') : 'Failed');
+                        }
+                    }
+                    feedback.textContent = `✅ Added ${questions.length} question${questions.length > 1 ? 's' : ''}!`;
+                    refreshQuestions();
+                    setTimeout(() => {
+                        closeAddQuestion();
+                        feedback.textContent = '';
+                    }, 1000);
+                } catch (err) {
+                    feedback.textContent = '❌ ' + err.message;
+                }
+                return;
+            }
+
             const payload = {
-                quiz: document.getElementById('aq-quiz').value,
-                type: document.getElementById('aq-type').value,
+                quiz,
+                type,
                 question: document.getElementById('aq-question').value,
                 options: Array.from(document.querySelectorAll('#aq-options-list input')).map(i => i.value).filter(v => v),
                 correct: document.getElementById('aq-correct').value,
                 explanation: document.getElementById('aq-explanation').value
             };
-            const feedback = document.getElementById('aq-feedback');
+            if (!payload.question || !payload.correct || !payload.explanation) {
+                feedback.textContent = '❌ Please fill all required fields';
+                return;
+            }
             feedback.textContent = 'Submitting...';
             try {
                 const response = await fetch(CONFIG.questionsUrl + '?action=addQuestion', {
@@ -2189,10 +2277,24 @@ Focus on actionable knowledge I can apply immediately in my maintenance work.`;
         <div id="add-question-modal" class="modal hidden">
             <div class="modal-content">
                 <h3>Add Question</h3>
-                <form id="add-question-form" onsubmit="submitAddQuestion(event)">
+                <form id="add-question-form" novalidate onsubmit="submitAddQuestion(event)">
                     <label>Quiz
                         <select id="aq-quiz"></select>
                     </label>
+                    <label>GPT Quiz (optional)
+                        <textarea id="aq-bulk" placeholder="Paste GPT-formatted quiz here"></textarea>
+                    </label>
+                    <details>
+                        <summary>Sample Format</summary>
+                        <pre>
+1. What is 2+2?
+A. 3
+B. 4
+C. 5
+Answer: B
+Explanation: 2+2=4.
+                        </pre>
+                    </details>
                     <label>Question
                         <textarea id="aq-question" required></textarea>
                     </label>


### PR DESCRIPTION
## Summary
- parse GPT-formatted quiz text into question objects with error reporting
- allow bulk question submission using parsed GPT text
- show sample GPT quiz format in add-question modal for guidance

## Testing
- `npm test` (fails: enoent package.json)
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a9b7ef44e883268b51fa4fb7a6b011