### PR TITLE
Add timeout and retry to quiz data fetches

### DIFF
--- a/index.html
+++ b/index.html
@@ -1531,6 +1531,17 @@
             }
         }
 
+        async function fetchWithTimeout(resource, options = {}, timeout = 10000) {
+            const controller = new AbortController();
+            const id = setTimeout(() => controller.abort(), timeout);
+            try {
+                const response = await fetch(resource, { ...options, signal: controller.signal });
+                return response;
+            } finally {
+                clearTimeout(id);
+            }
+        }
+
         async function testConnection() {
             const statusElement = document.getElementById('connection-status');
             if (!statusElement) return;
@@ -1539,7 +1550,7 @@
             statusElement.className = 'status-indicator status-warning';
             
             try {
-                const response = await fetch(CONFIG.webAppUrl + '?test=true');
+                const response = await fetchWithTimeout(CONFIG.webAppUrl + '?test=true');
                 if (response.ok) {
                     statusElement.textContent = '✅ Connected';
                     statusElement.className = 'status-indicator status-connected';
@@ -1548,8 +1559,11 @@
                     statusElement.className = 'status-indicator status-disconnected';
                 }
             } catch (error) {
-                statusElement.textContent = '❌ Error';
+                statusElement.textContent = error.name === 'AbortError' ? '⏱️ Timeout' : '❌ Error';
                 statusElement.className = 'status-indicator status-disconnected';
+                if (error.name === 'AbortError' && confirm('Connection test timed out. Retry?')) {
+                    return testConnection();
+                }
             }
         }
 
@@ -1659,7 +1673,7 @@
 
         async function loadAvailableQuizzes() {
             try {
-                const response = await fetch(CONFIG.quizListUrl);
+                const response = await fetchWithTimeout(CONFIG.quizListUrl);
                 const data = await response.json();
                 
                 if (data.success && data.quizzes) {
@@ -1682,6 +1696,11 @@
                     select.appendChild(customOption);
                 }
             } catch (error) {
+                if (error.name === 'AbortError') {
+                    if (confirm('Loading quiz list timed out. Retry?')) {
+                        return loadAvailableQuizzes();
+                    }
+                }
                 console.log('Could not load quiz list from sheets, using defaults');
             }
         }
@@ -1823,9 +1842,9 @@
             console.log('Data being sent:', quizResults);
             
             try {
-                const response = await fetch(CONFIG.webAppUrl, {
+                const response = await fetchWithTimeout(CONFIG.webAppUrl, {
                     method: 'POST',
-                    headers: { 
+                    headers: {
                         'Content-Type': 'text/plain;charset=utf-8'  // Changed from application/json
                     },
                     body: JSON.stringify(quizResults)
@@ -1846,7 +1865,18 @@
             } catch (error) {
                 console.error('Save error details:', error);
                 saveError = error.message || 'Network error';
-                
+
+                if (error.name === 'AbortError') {
+                    saveError = 'Request timed out';
+                    if (submitButton) {
+                        submitButton.textContent = originalText;
+                        submitButton.disabled = false;
+                    }
+                    if (confirm('Submission timed out. Retry?')) {
+                        return submitQuiz();
+                    }
+                }
+
                 // Check if it's a CORS error
                 if (error.message.includes('CORS') || error.message.includes('Access-Control')) {
                     saveError = 'CORS policy error - Google Apps Script may need CORS configuration';
@@ -1919,9 +1949,9 @@
         async function loadQuizQuestions() {
             try {
                 const url = `${CONFIG.questionsUrl}&quiz=${encodeURIComponent(currentQuiz)}`;
-                const response = await fetch(url);
+                const response = await fetchWithTimeout(url);
                 const data = await response.json();
-                
+
                 if (data.success && data.questions && data.questions.length > 0) {
                     currentQuestions = shuffleArray([...data.questions]);
                     usingFallbackQuestions = false;
@@ -1929,11 +1959,16 @@
                     throw new Error('No questions found');
                 }
             } catch (error) {
+                if (error.name === 'AbortError') {
+                    if (confirm('Loading questions timed out. Retry?')) {
+                        return loadQuizQuestions();
+                    }
+                }
                 console.log('Using default questions');
                 currentQuestions = shuffleArray([...DEFAULT_QUESTIONS]);
                 usingFallbackQuestions = true;
             }
-            
+
             generateQuizHTML();
             showSection('quiz-section');
             updateProgress();


### PR DESCRIPTION
## Summary
- Add `fetchWithTimeout` utility using `AbortController`
- Apply timed fetches with retry prompts in initialization, quiz submission, and question loading

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx prettier --check index.html` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b66ff5d88326b84dd0c55e3d27aa