### PR TITLE
Handle short answer validation before scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -1833,7 +1833,7 @@
                 time: new Date().toLocaleTimeString(),
                 questions: allQuestions,
                 answers: sanitizedAnswers,
-                manualReview: manualReview,
+                manualReview,
                 questionsSource: usingFallbackQuestions ? 'Default' : 'Google Sheets'
             };
 

--- a/index.html
+++ b/index.html
@@ -1463,6 +1463,7 @@
         // App state
         let currentQuestions = [];
         let wrongAnswers = [];
+        let manualReview = [];
         let currentQuiz = 'Bearing Maintenance Quiz';
         let usingFallbackQuestions = false;
         const GEORGE_IMAGES = {
@@ -1757,12 +1758,14 @@
             
             let score = 0;
             wrongAnswers = [];
+            manualReview = [];
             const allAnswers = [];
             const allQuestions = [];
             
             currentQuestions.forEach((question, index) => {
                 let userAnswer;
                 let isCorrect = false;
+                let needsReview = false;
 
                 allQuestions.push(question.question);
 
@@ -1788,7 +1791,22 @@
                     const textArea = document.getElementById(`q${index}_text`);
                     userAnswer = textArea ? textArea.value.trim() : '';
                     allAnswers.push(userAnswer || 'No answer');
-                    isCorrect = userAnswer.length > 0;
+
+                    const acceptableAnswers = question.acceptableAnswers || question.answers;
+
+                    if (Array.isArray(acceptableAnswers) && acceptableAnswers.length > 0) {
+                        isCorrect = acceptableAnswers.some(ans => ans.trim().toLowerCase() === userAnswer.toLowerCase());
+                    } else {
+                        isCorrect = false;
+                        needsReview = userAnswer.length > 0;
+                    }
+
+                    if (needsReview) {
+                        manualReview.push({
+                            question: question.question,
+                            userAnswer: userAnswer
+                        });
+                    }
                 }
 
                 if (isCorrect) {
@@ -1797,7 +1815,8 @@
                     wrongAnswers.push({
                         question: question.question,
                         explanation: question.explanation,
-                        userAnswer: userAnswer
+                        userAnswer: userAnswer,
+                        needsReview: needsReview
                     });
                 }
             });
@@ -1813,6 +1832,7 @@
                 time: new Date().toLocaleTimeString(),
                 questions: allQuestions,
                 answers: allAnswers,
+                manualReview: manualReview,
                 questionsSource: usingFallbackQuestions ? 'Default' : 'Google Sheets'
             };
 

--- a/index.html
+++ b/index.html
@@ -1822,6 +1822,7 @@
             });
 
             // Save results to Google Sheets with enhanced error handling
+            const sanitizedAnswers = allAnswers.map(ans => sanitizeHTML(ans));
             const quizResults = {
                 name: window.quizTakerName,
                 quiz: currentQuiz,
@@ -1831,7 +1832,7 @@
                 date: new Date().toLocaleDateString(),
                 time: new Date().toLocaleTimeString(),
                 questions: allQuestions,
-                answers: allAnswers,
+                answers: sanitizedAnswers,
                 manualReview: manualReview,
                 questionsSource: usingFallbackQuestions ? 'Default' : 'Google Sheets'
             };


### PR DESCRIPTION
## Summary
- Compare short answers against an acceptable answer list and flag unmatched responses for manual review.
- Track manual review items and include them in the results payload.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b66d5dc0832683df6cbfd3b9dcfe