### PR TITLE
Load quizzes from Google Sheet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,4 +1,16 @@
 const SHEET_NAME = 'Questions';
+const QUIZ_LIST_SHEET_NAME = 'Quiz Name';
+
+function doGet(e) {
+  const action = e.parameter.action;
+  if (action === 'getQuizzes') {
+    return handleGetQuizzes();
+  }
+  return ContentService.createTextOutput(JSON.stringify({
+    success: false,
+    errors: ['Unsupported action']
+  })).setMimeType(ContentService.MimeType.JSON);
+}
 
 function doPost(e) {
   const action = e.parameter.action;
@@ -121,5 +133,26 @@ function handleAddQuestions(e) {
     success: true,
     inserted: rows.length,
     errors: errors,
+  })).setMimeType(ContentService.MimeType.JSON);
+}
+
+function handleGetQuizzes() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName(QUIZ_LIST_SHEET_NAME);
+  if (!sheet) {
+    return ContentService.createTextOutput(JSON.stringify({
+      success: false,
+      errors: ['Quiz list sheet not found'],
+    })).setMimeType(ContentService.MimeType.JSON);
+  }
+
+  const lastRow = sheet.getLastRow();
+  const quizzes = lastRow > 1
+    ? sheet.getRange(2, 1, lastRow - 1, 1).getValues().flat().filter(String)
+    : [];
+
+  return ContentService.createTextOutput(JSON.stringify({
+    success: true,
+    quizzes: quizzes,
   })).setMimeType(ContentService.MimeType.JSON);
 }

--- a/index.html
+++ b/index.html
@@ -1806,30 +1806,44 @@
         }
 
         async function loadAvailableQuizzes() {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 5000);
+
             try {
-                const response = await fetch(CONFIG.quizListUrl);
+                const response = await fetch(CONFIG.quizListUrl, { signal: controller.signal });
+                clearTimeout(timeout);
                 const data = await response.json();
-                
+
+                const select = document.getElementById('quiz-select');
+                if (!select) return;
+
+                select.innerHTML = '';
+
                 if (data.success && data.quizzes) {
-                    const select = document.getElementById('quiz-select');
-                    if (!select) return;
-                    
-                    select.innerHTML = '';
-                    
                     data.quizzes.forEach(quiz => {
                         const option = document.createElement('option');
                         option.value = quiz;
                         option.textContent = quiz;
                         select.appendChild(option);
                     });
+                } else {
+                    const option = document.createElement('option');
+                    option.disabled = true;
+                    option.textContent = 'No quizzes available';
+                    select.appendChild(option);
                 }
             } catch (error) {
-                console.error('Could not load quiz list from sheets', error);
                 const select = document.getElementById('quiz-select');
+                if (error.name === 'AbortError') {
+                    if (confirm('Loading quiz list timed out. Retry?')) {
+                        return loadAvailableQuizzes();
+                    }
+                }
+                console.error('Could not load quiz list from sheets', error);
                 if (select) {
                     select.innerHTML = '';
                     const option = document.createElement('option');
-                    option.value = '';
+                    option.disabled = true;
                     option.textContent = 'No quizzes available';
                     select.appendChild(option);
                 }

--- a/index.html
+++ b/index.html
@@ -1524,6 +1524,21 @@
             document.documentElement.setAttribute('data-theme', savedTheme);
         }
 
+        async function fetchWithTimeout(resource, options = {}) {
+            const { timeout = 5000 } = options;
+            const controller = new AbortController();
+            const id = setTimeout(() => controller.abort(), timeout);
+            try {
+                const response = await fetch(resource, {
+                    ...options,
+                    signal: controller.signal,
+                });
+                return response;
+            } finally {
+                clearTimeout(id);
+            }
+        }
+
         // Define ALL functions at the top level
         function toggleAdmin() {
             const dropdown = document.getElementById('admin-dropdown');
@@ -1806,12 +1821,8 @@
         }
 
         async function loadAvailableQuizzes() {
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 5000);
-
             try {
-                const response = await fetch(CONFIG.quizListUrl, { signal: controller.signal });
-                clearTimeout(timeout);
+                const response = await fetchWithTimeout(CONFIG.quizListUrl);
                 const data = await response.json();
 
                 const select = document.getElementById('quiz-select');

--- a/index.html
+++ b/index.html
@@ -1463,8 +1463,7 @@
         // App state
         let currentQuestions = [];
         let wrongAnswers = [];
-        let currentQuiz = 'Bearing Maintenance Quiz';
-        let previousQuizSelection = currentQuiz;
+        let currentQuiz = '';
         let usingFallbackQuestions = false;
         const GEORGE_IMAGES = {
             welcome: 'https://raw.githubusercontent.com/rogerhunter00-afk/ALS-quiz/main/images/george-welcome.png',
@@ -1823,15 +1822,9 @@
                         option.textContent = quiz;
                         select.appendChild(option);
                     });
-                    
-                    // Add custom option
-                    const customOption = document.createElement('option');
-                    customOption.value = 'custom';
-                    customOption.textContent = 'Custom Quiz Name...';
-                    select.appendChild(customOption);
                 }
             } catch (error) {
-                console.log('Could not load quiz list from sheets, using defaults');
+                console.error('Could not load quiz list from sheets');
             }
         }
 
@@ -1845,18 +1838,11 @@
                 return;
             }
 
-            if (selectedQuiz === 'custom') {
-                const customQuiz = prompt('Enter quiz name:');
-                if (customQuiz === null || !customQuiz.trim()) {
-                    alert('Quiz selection canceled. Please choose a quiz to continue.');
-                    quizSelect.value = previousQuizSelection;
-                    return;
-                }
-                currentQuiz = customQuiz.trim();
-            } else {
-                currentQuiz = selectedQuiz;
-                previousQuizSelection = selectedQuiz;
+            if (!selectedQuiz) {
+                alert('Please choose a quiz to continue.');
+                return;
             }
+            currentQuiz = selectedQuiz;
 
             window.quizTakerName = sanitizeHTML(name);
             showSection('loading-section');
@@ -2509,12 +2495,7 @@ Explanation: 2+2=4.
                     
                     <div class="quiz-selector">
                         <h3>Choose Your Test</h3>
-                        <select id="quiz-select">
-                            <option value="Bearing Maintenance Quiz">Bearing Maintenance Quiz</option>
-                            <option value="Motor Troubleshooting">Motor Troubleshooting</option>
-                            <option value="Electrical Safety">Electrical Safety</option>
-                            <option value="custom">Custom Quiz Name...</option>
-                        </select>
+                        <select id="quiz-select"></select>
                     </div>
                     
                     <div class="start-quiz-section">
@@ -2568,17 +2549,7 @@ Explanation: 2+2=4.
         // Initialize when DOM loads
         document.addEventListener('DOMContentLoaded', function() {
             initializeTheme(); // Initialize theme first
-            initializeApp().finally(() => {
-                const quizSelect = document.getElementById('quiz-select');
-                if (quizSelect) {
-                    previousQuizSelection = quizSelect.value;
-                    quizSelect.addEventListener('change', () => {
-                        if (quizSelect.value !== 'custom') {
-                            previousQuizSelection = quizSelect.value;
-                        }
-                    });
-                }
-            });
+            initializeApp();
 
             // Close admin dropdown when clicking outside
             document.addEventListener('click', function(event) {

--- a/index.html
+++ b/index.html
@@ -1824,7 +1824,15 @@
                     });
                 }
             } catch (error) {
-                console.error('Could not load quiz list from sheets');
+                console.error('Could not load quiz list from sheets', error);
+                const select = document.getElementById('quiz-select');
+                if (select) {
+                    select.innerHTML = '';
+                    const option = document.createElement('option');
+                    option.value = '';
+                    option.textContent = 'No quizzes available';
+                    select.appendChild(option);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Provide Apps Script endpoint to return quiz names from a "Quiz Name" sheet
- Populate quiz selector dynamically from Google Sheet and remove hard-coded options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c540a9f883268c850c43a5d48451