### PR TITLE
Fix loading spinner colors and sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             background: #4a6741;
         }
         
-        * {
+        *, *::before, *::after {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
@@ -1282,13 +1282,14 @@
         .loading-spinner {
             width: 60px;
             height: 60px;
-            border: 6px solid #ecf0f1;
-            border-top: 6px solid var(--primary-color);
+            border: 6px solid var(--light-color);
+            border-top-color: var(--primary-color);
             border-radius: 50%;
             animation: spin 1s linear infinite;
             position: relative;
+            box-sizing: border-box;
         }
-        
+
         .loading-spinner::after {
             content: '';
             position: absolute;
@@ -1296,11 +1297,12 @@
             left: 50%;
             width: 30px;
             height: 30px;
-            border: 3px solid transparent;
-            border-top: 3px solid var(--secondary-color);
+            border: 3px solid var(--light-color);
+            border-top-color: var(--secondary-color);
             border-radius: 50%;
             transform: translate(-50%, -50%);
             animation: spin 0.7s linear infinite reverse;
+            box-sizing: border-box;
         }
         
         .loading-text {


### PR DESCRIPTION
## Summary
- ensure global box-sizing applies to pseudo-elements
- color and size loading spinner with theme variables so borders stay within circle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c62b7c748326be3605cdb7c8c033