### PR TITLE
chore: align color variables with brand palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,13 +67,13 @@
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             line-height: 1.6;
-            color: #2c3e50;
+            color: var(--dark-color);
             background: var(--background-gradient);
             min-height: 100vh;
             padding: 15px;
             transition: all 0.3s ease;
         }
-        
+
         .container {
             max-width: 900px;
             margin: 0 auto;
@@ -88,7 +88,7 @@
         .landing-page {
             text-align: center;
             padding: 50px 30px;
-            background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+            background: var(--background-gradient);
             position: relative;
             overflow: hidden;
         }
@@ -98,7 +98,7 @@
             position: absolute;
             top: 20px;
             right: 80px;
-            background: linear-gradient(135deg, #f39c12, #e67e22);
+            background: linear-gradient(135deg, var(--warning-color), var(--danger-color));
             color: white;
             border: none;
             padding: 10px 18px;
@@ -125,7 +125,7 @@
         }
         
         [data-theme="dark"] .theme-toggle {
-            background: linear-gradient(135deg, #f1c40f, #f39c12);
+            background: linear-gradient(135deg, var(--warning-color), var(--danger-color));
         }
         
         [data-theme="dark"] .theme-toggle::before {

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
             --warning-color: #ff6b35;
             --dark-color: #000b33;
             --light-color: #f0f4ff;
-            --background-gradient: linear-gradient(135deg, #001b5c 0%, #003f88 100%);
+            --background-gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
         }
 
         [data-theme="dark"] {
@@ -22,7 +22,7 @@
             --warning-color: #ff944d;
             --dark-color: #f0f4ff;
             --light-color: #001233;
-            --background-gradient: linear-gradient(135deg, #000b33 0%, #001b5c 100%);
+            --background-gradient: linear-gradient(135deg, var(--light-color) 0%, var(--primary-color) 100%);
         }
 
         [data-theme="dark"] body {

--- a/index.html
+++ b/index.html
@@ -6,23 +6,23 @@
     <title>Laundry Engineers Quiz</title>
     <style>
         :root {
-            --primary-color: #3498db;
-            --secondary-color: #2ecc71;
-            --danger-color: #e74c3c;
-            --warning-color: #f39c12;
-            --dark-color: #2c3e50;
-            --light-color: #ecf0f1;
-            --background-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            --primary-color: #001b5c;
+            --secondary-color: #003f88;
+            --danger-color: #d7263d;
+            --warning-color: #ff6b35;
+            --dark-color: #000b33;
+            --light-color: #f0f4ff;
+            --background-gradient: linear-gradient(135deg, #001b5c 0%, #003f88 100%);
         }
-        
+
         [data-theme="dark"] {
-            --primary-color: #5dade2;
-            --secondary-color: #58d68d;
-            --danger-color: #ec7063;
-            --warning-color: #f7dc6f;
-            --dark-color: #1a252f;
-            --light-color: #34495e;
-            --background-gradient: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+            --primary-color: #4d6fb6;
+            --secondary-color: #6f8cd9;
+            --danger-color: #ff5a6a;
+            --warning-color: #ff944d;
+            --dark-color: #f0f4ff;
+            --light-color: #001233;
+            --background-gradient: linear-gradient(135deg, #000b33 0%, #001b5c 100%);
         }
         
         [data-theme="dark"] body {

--- a/index.html
+++ b/index.html
@@ -24,38 +24,38 @@
             --light-color: #001233;
             --background-gradient: linear-gradient(135deg, #000b33 0%, #001b5c 100%);
         }
-        
+
         [data-theme="dark"] body {
             background: var(--background-gradient);
-            color: #ecf0f1;
+            color: var(--dark-color);
         }
-        
+
         [data-theme="dark"] .container {
-            background: #2c3e50;
-            color: #ecf0f1;
+            background: var(--light-color);
+            color: var(--dark-color);
         }
-        
+
         [data-theme="dark"] .landing-page {
-            background: linear-gradient(135deg, #34495e, #2c3e50);
+            background: var(--background-gradient);
         }
-        
+
         [data-theme="dark"] .interactive-section,
         [data-theme="dark"] .question,
         [data-theme="dark"] .results-header,
         [data-theme="dark"] .george-score-container,
         [data-theme="dark"] .back-button-container {
-            background: #34495e;
-            color: #ecf0f1;
+            background: var(--light-color);
+            color: var(--dark-color);
         }
-        
+
         [data-theme="dark"] .option {
-            background: #2c3e50;
-            color: #ecf0f1;
+            background: var(--secondary-color);
+            color: var(--dark-color);
         }
-        
+
         [data-theme="dark"] .option:hover,
         [data-theme="dark"] .option.selected {
-            background: #4a6741;
+            background: var(--primary-color);
         }
         
         * {


### PR DESCRIPTION
## Summary
- update CSS variables to use brand deep blue and complementary shades
- adjust dark theme palette for better contrast

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c69cc8008326a053f1238c40daa8