### PR TITLE
Refactor colors to CSS variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
             --warning-color: #f39c12;
             --dark-color: #2c3e50;
             --light-color: #ecf0f1;
+            --text-color: #2c3e50;
             --background-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         }
         
@@ -22,35 +23,36 @@
             --warning-color: #f7dc6f;
             --dark-color: #1a252f;
             --light-color: #34495e;
-            --background-gradient: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+            --text-color: #ecf0f1;
+            --background-gradient: linear-gradient(135deg, var(--dark-color) 0%, var(--light-color) 100%);
         }
-        
+
         [data-theme="dark"] body {
             background: var(--background-gradient);
-            color: #ecf0f1;
+            color: var(--text-color);
         }
-        
+
         [data-theme="dark"] .container {
-            background: #2c3e50;
-            color: #ecf0f1;
+            background: var(--dark-color);
+            color: var(--text-color);
         }
-        
+
         [data-theme="dark"] .landing-page {
-            background: linear-gradient(135deg, #34495e, #2c3e50);
+            background: linear-gradient(135deg, var(--light-color), var(--dark-color));
         }
-        
+
         [data-theme="dark"] .interactive-section,
         [data-theme="dark"] .question,
         [data-theme="dark"] .results-header,
         [data-theme="dark"] .george-score-container,
         [data-theme="dark"] .back-button-container {
-            background: #34495e;
-            color: #ecf0f1;
+            background: var(--light-color);
+            color: var(--text-color);
         }
-        
+
         [data-theme="dark"] .option {
-            background: #2c3e50;
-            color: #ecf0f1;
+            background: var(--dark-color);
+            color: var(--text-color);
         }
         
         [data-theme="dark"] .option:hover,
@@ -67,7 +69,7 @@
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             line-height: 1.6;
-            color: #2c3e50;
+            color: var(--text-color);
             background: var(--background-gradient);
             min-height: 100vh;
             padding: 15px;
@@ -98,7 +100,7 @@
             position: absolute;
             top: 20px;
             right: 80px;
-            background: linear-gradient(135deg, #f39c12, #e67e22);
+            background: linear-gradient(135deg, var(--warning-color), #e67e22);
             color: white;
             border: none;
             padding: 10px 18px;
@@ -125,7 +127,7 @@
         }
         
         [data-theme="dark"] .theme-toggle {
-            background: linear-gradient(135deg, #f1c40f, #f39c12);
+            background: linear-gradient(135deg, #f1c40f, var(--warning-color));
         }
         
         [data-theme="dark"] .theme-toggle::before {
@@ -156,7 +158,7 @@
         
         .landing-header h1 {
             font-size: 3.5em;
-            color: #1a252f;
+            color: var(--text-color);
             margin-bottom: 8px;
             font-weight: 800;
             text-shadow: 2px 4px 8px rgba(0,0,0,0.1);
@@ -165,7 +167,7 @@
         
         .landing-header p {
             font-size: 1.4em;
-            color: #34495e;
+            color: var(--text-color);
             margin-bottom: 25px;
             font-weight: 500;
         }
@@ -200,7 +202,7 @@
         
         .section-title {
             font-size: 1.8em;
-            color: #2c3e50;
+            color: var(--text-color);
             margin-bottom: 25px;
             font-weight: 700;
         }
@@ -226,7 +228,7 @@
         
         .name-input input:focus {
             outline: none;
-            border-color: #3498db;
+            border-color: var(--primary-color);
             box-shadow: 0 0 25px rgba(52, 152, 219, 0.15), 0 4px 20px rgba(0,0,0,0.1);
             background: white;
             transform: translateY(-2px);
@@ -260,11 +262,11 @@
             left: 0;
             right: 0;
             height: 4px;
-            background: linear-gradient(90deg, #3498db, #2ecc71, #e74c3c, #f39c12);
+            background: linear-gradient(90deg, var(--primary-color), var(--secondary-color), var(--danger-color), var(--warning-color));
         }
         
         .quiz-selector h3 {
-            color: #2c3e50;
+            color: var(--text-color);
             margin-bottom: 15px;
             font-size: 1.2em;
             font-weight: 600;
@@ -295,7 +297,7 @@
         
         .quiz-selector select:focus {
             outline: none;
-            border-color: #3498db;
+            border-color: var(--primary-color);
             box-shadow: 0 0 15px rgba(52, 152, 219, 0.2);
             transform: translateY(-1px);
         }
@@ -342,7 +344,7 @@
         }
         
         .btn-primary {
-            background: linear-gradient(135deg, #3498db, #2980b9);
+            background: linear-gradient(135deg, var(--primary-color), #2980b9);
             color: white;
             box-shadow: 0 6px 20px rgba(52, 152, 219, 0.3);
         }
@@ -354,7 +356,7 @@
         }
         
         .btn-success {
-            background: linear-gradient(135deg, #27ae60, #2ecc71);
+            background: linear-gradient(135deg, #27ae60, var(--secondary-color));
             color: white;
             box-shadow: 0 8px 25px rgba(39, 174, 96, 0.3);
             font-size: 1.4em;
@@ -411,7 +413,7 @@
             padding: 15px;
             background: rgba(52, 152, 219, 0.1);
             border-radius: 10px;
-            color: #34495e;
+            color: var(--text-color);
             font-size: 0.95em;
             animation: fadeIn 1s ease-out 1.2s both;
         }
@@ -425,7 +427,7 @@
         }
         
         .admin-toggle {
-            background: #34495e;
+            background: var(--light-color);
             color: white;
             border: none;
             padding: 12px 20px;
@@ -460,9 +462,9 @@
             font-weight: 600;
         }
         
-        .status-connected { background: #d4edda; color: #155724; }
-        .status-warning { background: #fff3cd; color: #856404; }
-        .status-disconnected { background: #f8d7da; color: #721c24; }
+        .status-connected { background: var(--secondary-color); color: var(--text-color); }
+        .status-warning { background: var(--warning-color); color: var(--text-color); }
+        .status-disconnected { background: var(--danger-color); color: var(--text-color); }
         
         /* Quiz Section - IMPROVED LAYOUT */
         .quiz-section {
@@ -482,7 +484,7 @@
         
         .quiz-title {
             font-size: 2.2em;
-            color: #2c3e50;
+            color: var(--text-color);
             margin-bottom: 20px;
             font-weight: 700;
             display: flex;
@@ -498,7 +500,7 @@
         
         /* Enhanced Progress Animation */
         .progress-container {
-            background: #ecf0f1;
+            background: var(--light-color);
             border-radius: 25px;
             height: 14px;
             margin: 20px 0;
@@ -693,7 +695,7 @@
         }
         
         .question-number {
-            background: linear-gradient(135deg, #3498db, #2980b9);
+            background: linear-gradient(135deg, var(--primary-color), #2980b9);
             color: white;
             padding: 10px 18px;
             border-radius: 25px;
@@ -705,7 +707,7 @@
         }
         
         .question h3 {
-            color: #2c3e50;
+            color: var(--text-color);
             margin-bottom: 25px;
             font-size: 1.4em;
             line-height: 1.5;
@@ -851,7 +853,7 @@
         .option input {
             margin-right: 18px;
             transform: scale(1.4);
-            accent-color: #3498db;
+            accent-color: var(--primary-color);
         }
         
         .option label {
@@ -859,7 +861,7 @@
             cursor: pointer;
             flex: 1;
             font-weight: 500;
-            color: #2c3e50;
+            color: var(--text-color);
         }
         
         .text-answer {
@@ -877,7 +879,7 @@
         
         .text-answer:focus {
             outline: none;
-            border-color: #3498db;
+            border-color: var(--primary-color);
             box-shadow: 0 0 15px rgba(52, 152, 219, 0.2);
             background: white;
             transform: translateY(-2px);
@@ -910,7 +912,7 @@
         
         .results-header h2 {
             font-size: 2.5em;
-            color: #2c3e50;
+            color: var(--text-color);
             font-weight: 700;
             margin-bottom: 15px;
             display: flex;
@@ -1011,11 +1013,11 @@
         }
         
         .score-display.low { 
-            color: #e74c3c;
+            color: var(--danger-color);
             text-shadow: 2px 2px 8px rgba(231, 76, 60, 0.3);
         }
         .score-display.medium { 
-            color: #f39c12;
+            color: var(--warning-color);
             text-shadow: 2px 2px 8px rgba(243, 156, 18, 0.3);
         }
         .score-display.high { 
@@ -1025,7 +1027,7 @@
         
         .score-message {
             font-size: 1.3em;
-            color: #2c3e50;
+            color: var(--text-color);
             font-weight: 600;
             line-height: 1.4;
         }
@@ -1090,11 +1092,11 @@
             left: 0;
             right: 0;
             height: 4px;
-            background: linear-gradient(90deg, #3498db, #2ecc71, #e74c3c, #f39c12);
+            background: linear-gradient(90deg, var(--primary-color), var(--secondary-color), var(--danger-color), var(--warning-color));
         }
         
         .chatgpt-help h4 {
-            color: #2c3e50;
+            color: var(--text-color);
             margin-bottom: 20px;
             font-size: 1.4em;
             display: flex;
@@ -1117,12 +1119,12 @@
             padding: 25px;
             border-radius: 15px;
             margin: 25px 0;
-            border-left: 4px solid #3498db;
+            border-left: 4px solid var(--primary-color);
             text-align: left;
         }
         
         .help-topics strong {
-            color: #2c3e50;
+            color: var(--text-color);
             font-size: 1.1em;
             display: block;
             margin-bottom: 15px;
@@ -1135,7 +1137,7 @@
         
         .help-topics li {
             margin: 10px 0;
-            color: #34495e;
+            color: var(--text-color);
             font-weight: 500;
             line-height: 1.4;
         }
@@ -1191,7 +1193,7 @@
         
         /* Perfect Score Celebration */
         .perfect-score {
-            background: linear-gradient(135deg, #27ae60, #2ecc71);
+            background: linear-gradient(135deg, #27ae60, var(--secondary-color));
             color: white;
             padding: 40px;
             border-radius: 20px;
@@ -1261,7 +1263,7 @@
         .loading-spinner {
             width: 60px;
             height: 60px;
-            border: 6px solid #ecf0f1;
+            border: 6px solid var(--light-color);
             border-top: 6px solid var(--primary-color);
             border-radius: 50%;
             animation: spin 1s linear infinite;
@@ -1285,7 +1287,7 @@
         .loading-text {
             font-size: 1.4em;
             font-weight: 600;
-            color: var(--dark-color);
+            color: var(--text-color);
             animation: pulse 2s ease-in-out infinite;
         }
         

--- a/index.html
+++ b/index.html
@@ -13,7 +13,9 @@
             --dark-color: #2c3e50;
             --light-color: #ecf0f1;
             --text-color: #2c3e50;
-            --background-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            --background-gradient: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+            --landing-title-color: #ffffff;
+            --landing-subtitle-color: #e0f7fa;
         }
         
         [data-theme="dark"] {
@@ -25,6 +27,8 @@
             --light-color: #34495e;
             --text-color: #ecf0f1;
             --background-gradient: linear-gradient(135deg, var(--dark-color) 0%, var(--light-color) 100%);
+            --landing-title-color: var(--text-color);
+            --landing-subtitle-color: var(--text-color);
         }
 
         [data-theme="dark"] body {
@@ -38,7 +42,7 @@
         }
 
         [data-theme="dark"] .landing-page {
-            background: linear-gradient(135deg, var(--light-color), var(--dark-color));
+            background: var(--background-gradient);
         }
 
         [data-theme="dark"] .interactive-section,
@@ -158,7 +162,7 @@
         
         .landing-header h1 {
             font-size: 3.5em;
-            color: var(--text-color);
+            color: var(--landing-title-color);
             margin-bottom: 8px;
             font-weight: 800;
             text-shadow: 2px 4px 8px rgba(0,0,0,0.1);
@@ -167,7 +171,7 @@
         
         .landing-header p {
             font-size: 1.4em;
-            color: var(--text-color);
+            color: var(--landing-subtitle-color);
             margin-bottom: 25px;
             font-weight: 500;
         }
@@ -1264,7 +1268,7 @@
             width: 60px;
             height: 60px;
             border: 6px solid var(--light-color);
-            border-top: 6px solid var(--primary-color);
+            border-top-color: var(--primary-color);
             border-radius: 50%;
             animation: spin 1s linear infinite;
             position: relative;

--- a/index.html
+++ b/index.html
@@ -59,10 +59,10 @@
             color: var(--text-color);
         }
         
-        [data-theme="dark"] .option:hover,
-        [data-theme="dark"] .option.selected {
-            background: #4a6741;
-        }
+[data-theme="dark"] .option:hover,
+[data-theme="dark"] .option.selected {
+    background: var(--secondary-color);
+}
         
         * {
             margin: 0;
@@ -94,7 +94,7 @@
         .landing-page {
             text-align: center;
             padding: 50px 30px;
-            background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+            background: linear-gradient(135deg, var(--light-color), color-mix(in srgb, var(--light-color), var(--dark-color) 10%));
             position: relative;
             overflow: hidden;
         }
@@ -104,7 +104,7 @@
             position: absolute;
             top: 20px;
             right: 80px;
-            background: linear-gradient(135deg, var(--warning-color), #e67e22);
+            background: linear-gradient(135deg, var(--warning-color), color-mix(in srgb, var(--warning-color), black 20%));
             color: white;
             border: none;
             padding: 10px 18px;
@@ -112,7 +112,7 @@
             font-size: 0.9em;
             font-weight: 600;
             cursor: pointer;
-            box-shadow: 0 4px 15px rgba(243, 156, 18, 0.3);
+            box-shadow: 0 4px 15px color-mix(in srgb, var(--warning-color), transparent 70%);
             z-index: 10;
             transition: all 0.3s ease;
             display: flex;
@@ -131,7 +131,7 @@
         }
         
         [data-theme="dark"] .theme-toggle {
-            background: linear-gradient(135deg, #f1c40f, var(--warning-color));
+            background: linear-gradient(135deg, color-mix(in srgb, var(--warning-color), white 20%), var(--warning-color));
         }
         
         [data-theme="dark"] .theme-toggle::before {
@@ -348,21 +348,21 @@
         }
         
         .btn-primary {
-            background: linear-gradient(135deg, var(--primary-color), #2980b9);
+            background: linear-gradient(135deg, var(--primary-color), color-mix(in srgb, var(--primary-color), black 20%));
             color: white;
-            box-shadow: 0 6px 20px rgba(52, 152, 219, 0.3);
+            box-shadow: 0 6px 20px color-mix(in srgb, var(--primary-color), transparent 70%);
         }
-        
+
         .btn-primary:hover {
-            background: linear-gradient(135deg, #2980b9, #1f618d);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color), black 20%), color-mix(in srgb, var(--primary-color), black 40%));
             transform: translateY(-3px);
-            box-shadow: 0 8px 25px rgba(52, 152, 219, 0.4);
+            box-shadow: 0 8px 25px color-mix(in srgb, var(--primary-color), transparent 60%);
         }
-        
+
         .btn-success {
-            background: linear-gradient(135deg, #27ae60, var(--secondary-color));
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), black 20%), var(--secondary-color));
             color: white;
-            box-shadow: 0 8px 25px rgba(39, 174, 96, 0.3);
+            box-shadow: 0 8px 25px color-mix(in srgb, var(--secondary-color), transparent 70%);
             font-size: 1.4em;
             padding: 22px 45px;
             position: relative;
@@ -388,9 +388,9 @@
         }
         
         .btn-success:hover {
-            background: linear-gradient(135deg, #219a52, #27ae60);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), black 30%), color-mix(in srgb, var(--secondary-color), black 10%));
             transform: translateY(-4px);
-            box-shadow: 0 12px 35px rgba(39, 174, 96, 0.4), 0 0 20px rgba(39, 174, 96, 0.2);
+            box-shadow: 0 12px 35px color-mix(in srgb, var(--secondary-color), transparent 60%), 0 0 20px color-mix(in srgb, var(--secondary-color), transparent 80%);
         }
         
         .btn-success:hover::before {
@@ -402,14 +402,14 @@
         }
         
         .btn-secondary {
-            background: #95a5a6;
+            background: color-mix(in srgb, var(--dark-color), var(--light-color) 50%);
             color: white;
             font-size: 0.9em;
             padding: 10px 20px;
         }
-        
+
         .btn-secondary:hover {
-            background: #7f8c8d;
+            background: color-mix(in srgb, var(--dark-color), var(--light-color) 30%);
         }
         
         .quiz-info {
@@ -603,10 +603,10 @@
         }
         
         .option:hover {
-            background: linear-gradient(135deg, #e3f2fd, #bbdefb);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color), white 80%), color-mix(in srgb, var(--primary-color), white 60%));
             border-color: var(--primary-color);
             transform: translateX(8px) translateY(-2px);
-            box-shadow: 0 8px 25px rgba(52, 152, 219, 0.2);
+            box-shadow: 0 8px 25px color-mix(in srgb, var(--primary-color), transparent 80%);
         }
         
         .option:hover::before {
@@ -614,9 +614,9 @@
         }
         
         .option.selected {
-            background: linear-gradient(135deg, #e3f2fd, #bbdefb);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color), white 80%), color-mix(in srgb, var(--primary-color), white 60%));
             border-color: var(--primary-color);
-            box-shadow: 0 5px 15px rgba(52, 152, 219, 0.3);
+            box-shadow: 0 5px 15px color-mix(in srgb, var(--primary-color), transparent 70%);
             transform: translateX(8px);
         }
         
@@ -699,7 +699,7 @@
         }
         
         .question-number {
-            background: linear-gradient(135deg, var(--primary-color), #2980b9);
+            background: linear-gradient(135deg, var(--primary-color), color-mix(in srgb, var(--primary-color), black 20%));
             color: white;
             padding: 10px 18px;
             border-radius: 25px;
@@ -707,7 +707,7 @@
             margin-bottom: 20px;
             display: inline-block;
             font-size: 1em;
-            box-shadow: 0 4px 15px rgba(52, 152, 219, 0.3);
+            box-shadow: 0 4px 15px color-mix(in srgb, var(--primary-color), transparent 70%);
         }
         
         .question h3 {
@@ -989,15 +989,15 @@
         
         
         .george-score-container.low-score {
-            background: linear-gradient(135deg, #fff5f5, #fed7d7);
-            border: 3px solid #feb2b2;
-            box-shadow: 0 20px 60px rgba(231, 76, 60, 0.2);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--danger-color), white 85%), color-mix(in srgb, var(--danger-color), white 60%));
+            border: 3px solid color-mix(in srgb, var(--danger-color), white 50%);
+            box-shadow: 0 20px 60px color-mix(in srgb, var(--danger-color), transparent 80%);
         }
-        
+
         .george-score-container.high-score {
-            background: linear-gradient(135deg, #f0fff4, #c6f6d5);
-            border: 3px solid #9ae6b4;
-            box-shadow: 0 20px 60px rgba(39, 174, 96, 0.2);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), white 85%), color-mix(in srgb, var(--secondary-color), white 60%));
+            border: 3px solid color-mix(in srgb, var(--secondary-color), white 50%);
+            box-shadow: 0 20px 60px color-mix(in srgb, var(--secondary-color), transparent 80%);
         }
         
         @keyframes angryPulse {
@@ -1016,17 +1016,17 @@
             text-shadow: 2px 2px 8px rgba(0,0,0,0.2);
         }
         
-        .score-display.low { 
+        .score-display.low {
             color: var(--danger-color);
-            text-shadow: 2px 2px 8px rgba(231, 76, 60, 0.3);
+            text-shadow: 2px 2px 8px color-mix(in srgb, var(--danger-color), transparent 70%);
         }
-        .score-display.medium { 
+        .score-display.medium {
             color: var(--warning-color);
-            text-shadow: 2px 2px 8px rgba(243, 156, 18, 0.3);
+            text-shadow: 2px 2px 8px color-mix(in srgb, var(--warning-color), transparent 70%);
         }
-        .score-display.high { 
-            color: #27ae60;
-            text-shadow: 2px 2px 8px rgba(39, 174, 96, 0.3);
+        .score-display.high {
+            color: var(--secondary-color);
+            text-shadow: 2px 2px 8px color-mix(in srgb, var(--secondary-color), transparent 70%);
         }
         
         .score-message {
@@ -1056,9 +1056,9 @@
         }
         
         .save-status.success {
-            background: linear-gradient(135deg, #d4edda, #c3e6cb);
-            color: #155724;
-            border: 2px solid #b8dabd;
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), white 80%), color-mix(in srgb, var(--secondary-color), white 60%));
+            color: color-mix(in srgb, var(--secondary-color), black 40%);
+            border: 2px solid color-mix(in srgb, var(--secondary-color), white 40%);
         }
         
         .save-status.success::before {
@@ -1067,9 +1067,9 @@
         }
         
         .save-status.error {
-            background: linear-gradient(135deg, #f8d7da, #f5c6cb);
-            color: #721c24;
-            border: 2px solid #f1b0b7;
+            background: linear-gradient(135deg, color-mix(in srgb, var(--danger-color), white 80%), color-mix(in srgb, var(--danger-color), white 60%));
+            color: color-mix(in srgb, var(--danger-color), black 40%);
+            border: 2px solid color-mix(in srgb, var(--danger-color), white 40%);
         }
         
         .save-status.error::before {
@@ -1152,7 +1152,7 @@
         }
         
         .chatgpt-link {
-            background: linear-gradient(135deg, #10a37f, #1a7f64);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), black 10%), color-mix(in srgb, var(--secondary-color), black 30%));
             color: white;
             padding: 22px 35px;
             border-radius: 15px;
@@ -1161,7 +1161,7 @@
             font-size: 1.2em;
             font-weight: 600;
             transition: all 0.3s ease;
-            box-shadow: 0 8px 25px rgba(16, 163, 127, 0.3);
+            box-shadow: 0 8px 25px color-mix(in srgb, var(--secondary-color), transparent 70%);
             position: relative;
             overflow: hidden;
         }
@@ -1178,9 +1178,9 @@
         }
         
         .chatgpt-link:hover {
-            background: linear-gradient(135deg, #0d8f6a, #155a4a);
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), black 20%), color-mix(in srgb, var(--secondary-color), black 40%));
             transform: translateY(-3px);
-            box-shadow: 0 12px 35px rgba(16, 163, 127, 0.4);
+            box-shadow: 0 12px 35px color-mix(in srgb, var(--secondary-color), transparent 60%);
         }
         
         .chatgpt-link:hover::before {
@@ -1197,13 +1197,13 @@
         
         /* Perfect Score Celebration */
         .perfect-score {
-            background: linear-gradient(135deg, #27ae60, var(--secondary-color));
+            background: linear-gradient(135deg, color-mix(in srgb, var(--secondary-color), black 20%), var(--secondary-color));
             color: white;
             padding: 40px;
             border-radius: 20px;
             margin-top: 30px;
             text-align: center;
-            box-shadow: 0 15px 40px rgba(39, 174, 96, 0.3);
+            box-shadow: 0 15px 40px color-mix(in srgb, var(--secondary-color), transparent 70%);
             position: relative;
             overflow: hidden;
         }


### PR DESCRIPTION
## Summary
- centralize text color and theme palette via CSS variables
- update progress bar and status indicators to use palette variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c69b69ec8326a5c48c25525ccf01