### PR TITLE
fix: restore ChatGPT deep-link to prevent stuck processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2154,7 +2154,13 @@
                 return `${window.quizTakerName}, George thinks you need to use your head more!`;
             }
         }
-        
+
+        // Build a deep link to ChatGPT with the provided prompt
+        function buildChatGPTURL(prompt) {
+            const encoded = encodeURIComponent(prompt);
+            return `https://chatgpt.com/?q=${encoded}`;
+        }
+
         function getChatGPTSection() {
     if (wrongAnswers.length === 0) {
         return `


### PR DESCRIPTION
## Summary
- add missing `buildChatGPTURL` helper to generate ChatGPT deep links

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cbbcf5248326a79e34832c68e433